### PR TITLE
Client Certs do not depend on https protocol #19

### DIFF
--- a/src/serviceFabricDiscoveryService/pkg/discovery/discoveryworker.go
+++ b/src/serviceFabricDiscoveryService/pkg/discovery/discoveryworker.go
@@ -79,8 +79,7 @@ func NewDiscoveryWorker(ctx context.Context, config *Config, name string) (*Prov
 		httpEntrypoint:       config.HttpEntrypoint,
 	}
 
-	if strings.HasPrefix(p.clusterManagementURL, "https") &&
-		(config.CertStoreSearchKey != "" || (config.CertificateKey != "" && config.Certificate != "")) {
+	if (config.CertStoreSearchKey != "" || (config.CertificateKey != "" && config.Certificate != "")) {
 		p.tlsConfig = &certstorehelper.ClientTLS{
 			Cert:               config.Certificate,
 			Key:                config.CertificateKey,


### PR DESCRIPTION
Client Certs used to connect to the Service Fabric Cluster do not depend on the https protocol. 

For my own use case, I prefer to hit the local cluster endpoint and not traverse the network or load balancer.