### PR TITLE
Fixed case where error in reading partitions can lead to using empty configuration

### DIFF
--- a/src/serviceFabricDiscoveryService/pkg/discovery/discoveryworker.go
+++ b/src/serviceFabricDiscoveryService/pkg/discovery/discoveryworker.go
@@ -213,6 +213,7 @@ func (p *Provider) fetchState() ([]ServiceItemExtended, error) {
 			partitions, err := p.sfClient.GetPartitions(app.ID, service.ID)
 			if err != nil {
 				log.Printf("failed to get partitions: %v", err)
+				return nil, err
 			}
 
 			for _, partition := range partitions.Items {


### PR DESCRIPTION
If e.g. a partition is being removed at a specific moment, there can be a 404 error in reading partitions from Service Fabric. Errors in reading partitions led to trying to use the invalid results, which eventually led to using effectively empty configuration until the next configuration read time. This means that any requests coming to that Traefik instance will fail for a few seconds.

Instead if there is an error when reading the partitions, return error so that the configuration is not used. Verified in practice that the partition reading errors no longer lead to empty configuration after the code fix.

Error in plugin logs without the fix:
time="2023-11-27T02:27:07Z" level=info msg="failed to get partitions: Service Fabric responded with error code 404 FABRIC_E_PARTITION_NOT_FOUND to request https://localhost:19080/Applications/<snip>/$/GetServices/<snip>/<snip>/$/GetPartitions/?api-version=3.0 with body &{0x302720 0xc000425240 0x517500}" 
time="2023-11-27T02:27:07Z" level=info msg="runtime error: invalid memory address or nil pointer dereference"